### PR TITLE
Quick & Dirty install & launch script for ArchLinux. Helpful until a proper installation setup works 

### DIFF
--- a/archlinux/dirty_install_archlinux.sh
+++ b/archlinux/dirty_install_archlinux.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+echo "Note: You need Python PIP, if not installed, this script is going to crash, run sudo pacman -Sy python2-pip and launch the script again if it happens."
+
+sudo pip2.7 install requests docopt BeautifulSoup setproctitle
+

--- a/archlinux/dirty_launch_archlinux.sh
+++ b/archlinux/dirty_launch_archlinux.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+cd ../pulseaudio_dlna
+PYTHONPATH=`pwd`/../ python2 __main__.py


### PR DESCRIPTION
Tried to run:

```sudo python setup.py --dry-run install```

On an Archlinux box, it threw an error / did not work.

Considering the small size of this utility, I decided I'd just go ahead and make it work quick & dirty way.

If you're ever interested in providing those two handy script for Archlinux users out there who just want to have it working, feel to merge, else, I'll keep them for myself :) 

Cheers,


PS: Oh and, that's an awesome work guy, works so much better than any other hours-to-get-it-working setups, so far.