### PR TITLE
added rx-475 as tested device

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ _pulseaudio-dlna_ was successfully tested on the follwing devices / applications
 - Samsung Smart TV LED40 (UE40ES6100)
 - Xbmc / Kodi
 - Philips Streamium NP2500 Network Player
+- Yamaha RX-475 (AV Receiver)
 - Majik DSM
 
 ## Supported encoders ##


### PR DESCRIPTION
Many other Yamaha AVRs, especially newer ones, will probably work as well, but I cannot test them.

I didn't want to include this in the readme, because it would clutter the list, but the UPNP/AV (DLNA) support has it's rough edges. I'm just leaving this here in case somebody googles this.

 - When the device is in "network standby" mode, the device is discovered, but it doesn't accept stream input. It must be turned on to work. You might think this is common sense, but 1) it's confusing that it's discoverable anyway and 2) it would turn itself on when receiving an AirPlay stream.
 - Either PulseAudio or the receiver, i guess the latter, buffers quite a lot. When testing, the latency varied between 4 and 10 seconds, for whatever reason. 
 - If the first thing you play is a very very short sound (< 1s), the connection will establish and terminate quickly, resulting in no sound to be played back.