### PR TITLE
Fix openSUSE spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ _Keep in mind that since i am not using those, i can hardly support them!_
 
 - Arch Linux
     [https://aur.archlinux.org/packages/pulseaudio-dlna/](https://aur.archlinux.org/packages/pulseaudio-dlna/)
-- OpenSUSE (_.rpm_)
+- openSUSE (_.rpm_)
     [http://packman.links2linux.de/package/pulseaudio-dlna](http://packman.links2linux.de/package/pulseaudio-dlna)
 
 


### PR DESCRIPTION
I'm glad you heard about the rpm I made for openSUSE!

Just a comment though: the right spelling is openSUSE, not OpenSUSE (even when you start a sentence with it). More information here: https://en.opensuse.org/Help:Style#openSUSE_spelling

It's a very unimportant detail but still ;)