### PR TITLE
Update UPnP devices during runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ dist/
 bin/
 include/
 local/
+
+*.iml
+.idea

--- a/pulseaudio_dlna/__main__.py
+++ b/pulseaudio_dlna/__main__.py
@@ -72,11 +72,11 @@ class PulseAudioDLNA(object):
 
     def shutdown(self, signal_number=None, frame=None):
         print('Application is shutting down.')
-        if self.pulse_process is not None:
+        if self.pulse_process is not None and self.pulse_process.is_alive():
             self.pulse_process.terminate()
-        if self.server_process is not None:
+        if self.server_process is not None and self.server_process.is_alive():
             self.server_process.terminate()
-        if self.listener_process is not None:
+        if self.listener_process is not None and self.listener_process.is_alive():
             self.listener_process.terminate()
         sys.exit(0)
 

--- a/pulseaudio_dlna/__main__.py
+++ b/pulseaudio_dlna/__main__.py
@@ -157,7 +157,7 @@ class PulseAudioDLNA(object):
             stream_server = pulseaudio_dlna.streamserver.ThreadedStreamServer(
                 host, port, bridges, message_queue)
         except socket.error:
-            logger.info(
+            logger.error(
                 'The streaming server could not bind to your specified port '
                 '({port}). Perhaps this is already in use? Application '
                 'terminates.'.format(port=port))

--- a/pulseaudio_dlna/listener.py
+++ b/pulseaudio_dlna/listener.py
@@ -18,6 +18,7 @@
 import SocketServer
 import socket
 import struct
+import setproctitle
 
 
 class SSDPRequestHandler(SocketServer.BaseRequestHandler):
@@ -41,3 +42,11 @@ class SSDPListener(SocketServer.UDPServer):
         multicast = struct.pack("=4sl", socket.inet_aton("239.255.255.250"), socket.INADDR_ANY)
         self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, multicast)
         self.renderers_holder = renderers_holder
+
+    def run(self):
+        setproctitle.setproctitle('ssdp_listener')
+        SocketServer.UDPServer.serve_forever(self)
+
+
+class ThreadedSSDPListener(SocketServer.ThreadingMixIn, SSDPListener):
+    pass

--- a/pulseaudio_dlna/listener.py
+++ b/pulseaudio_dlna/listener.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+
+# This file is part of pulseaudio-dlna.
+
+# pulseaudio-dlna is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# pulseaudio-dlna is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with pulseaudio-dlna.  If not, see <http://www.gnu.org/licenses/>.
+
+import SocketServer
+import socket
+import struct
+
+
+class SSDPRequestHandler(SocketServer.BaseRequestHandler):
+    def handle(self):
+        packet = self.request[0]
+        lines = packet.splitlines()
+        if len(lines) > 0 and self._is_notify_method(lines[0]):
+            self.server.renderers_holder.process_notify_request(packet)
+
+    def _is_notify_method(self, method_header):
+        method = self._get_method(method_header)
+        return method == 'NOTIFY'
+
+    def _get_method(self, method_header):
+        return method_header.split(' ')[0]
+
+
+class SSDPListener(SocketServer.UDPServer):
+    def __init__(self, renderers_holder):
+        SocketServer.UDPServer.__init__(self, ('', 1900), SSDPRequestHandler)
+        multicast = struct.pack("=4sl", socket.inet_aton("239.255.255.250"), socket.INADDR_ANY)
+        self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, multicast)
+        self.renderers_holder = renderers_holder

--- a/pulseaudio_dlna/plugins/upnp/__init__.py
+++ b/pulseaudio_dlna/plugins/upnp/__init__.py
@@ -29,8 +29,8 @@ class DLNAPlugin(pulseaudio_dlna.plugins.BasePlugin):
     def lookup(self, locations):
         renderers = []
         for url in locations:
-            renderer = pulseaudio_dlna.upnp.renderer.UpnpMediaRendererFactory.from_url(
-                url, pulseaudio_dlna.upnp.renderer.CoinedUpnpMediaRenderer)
+            renderer = pulseaudio_dlna.plugins.upnp.renderer.UpnpMediaRendererFactory.from_url(
+                url, pulseaudio_dlna.plugins.upnp.renderer.CoinedUpnpMediaRenderer)
             if renderer is not None:
                 renderers.append(renderer)
         return renderers

--- a/pulseaudio_dlna/pulseaudio.py
+++ b/pulseaudio_dlna/pulseaudio.py
@@ -458,23 +458,6 @@ class PulseWatcher(PulseAudio):
             self.fallback_sink.set_as_default_sink()
         bridge.sink.switch_streams_to_fallback_source()
 
-    def on_bridge_disconnected(self, stopped_bridge):
-
-        for sink in self.sinks:
-            if sink == stopped_bridge.sink:
-                stopped_bridge.sink = sink
-                break
-
-        reason = 'The device disconnected'
-        if len(stopped_bridge.sink.streams) > 1:
-            self.switch_back(stopped_bridge, reason)
-        elif len(stopped_bridge.sink.streams) == 1:
-            stream = stopped_bridge.sink.streams[0]
-            if not self._was_stream_moved(stream, stopped_bridge.sink):
-                self.switch_back(stopped_bridge, reason)
-        elif len(stopped_bridge.sink.streams) == 0:
-            pass
-
     def on_device_updated(self, sink_path):
         logger.info('PulseWatcher.on_device_updated "{path}"'.format(
             path=sink_path))

--- a/pulseaudio_dlna/pulseaudio.py
+++ b/pulseaudio_dlna/pulseaudio.py
@@ -527,12 +527,15 @@ class PulseWatcher(PulseAudio):
 
     def remove_device(self, device):
         self.devices.remove(device)
-        for bridge in self.bridges:
+        bridge_index_to_remove = None
+        for index, bridge in enumerate(self.bridges):
             if bridge.device == device:
                 logger.info('Remove "{}" sink ...'.format(bridge.sink.name))
+                bridge_index_to_remove = index
                 self.delete_null_sink(bridge.sink.module.index)
-                self.bridges.remove(bridge)
-                self.update()
-                logger.info('Removed the device "{name}."'.format(
-                    name=device.name))
                 break
+        if bridge_index_to_remove is not None:
+            self.bridges.pop(bridge_index_to_remove)
+            self.update()
+            logger.info('Removed the device "{name}."'.format(
+                name=device.name))

--- a/pulseaudio_dlna/pulseaudio.py
+++ b/pulseaudio_dlna/pulseaudio.py
@@ -28,6 +28,7 @@ import setproctitle
 import gobject
 import functools
 import copy
+import signal
 
 import pulseaudio_dlna.plugins.renderer
 import pulseaudio_dlna.notification
@@ -368,11 +369,20 @@ class PulseWatcher(PulseAudio):
         self.update()
         self.default_sink = self.fallback_sink
 
+    def terminate(self, signal_number=None, frame=None):
+        self.cleanup()
+        sys.exit(0)
+
     def run(self):
+        signal.signal(signal.SIGINT, self.terminate)
+        signal.signal(signal.SIGTERM, self.terminate)
         setproctitle.setproctitle('pulse_watcher')
         mainloop = gobject.MainLoop()
         gobject.timeout_add(500, self._check_message_queue)
-        mainloop.run()
+        try:
+            mainloop.run()
+        except KeyboardInterrupt:
+            pass
 
     def _check_message_queue(self):
         try:

--- a/pulseaudio_dlna/pulseaudio.py
+++ b/pulseaudio_dlna/pulseaudio.py
@@ -522,3 +522,24 @@ class PulseWatcher(PulseAudio):
                             bridge.device.label))
                         self.switch_back(
                             bridge, 'The device failed to started.')
+
+    def add_device(self, device):
+        self.devices.append(device)
+        sink = self.create_null_sink(
+            device.short_name, device.label)
+        self.bridges.append(PulseBridge(sink, device))
+        self.update()
+        logger.info('Added the device "{name}."'.format(
+            name=device.name))
+
+    def remove_device(self, device):
+        self.devices.remove(device)
+        for bridge in self.bridges:
+            if bridge.device == device:
+                logger.info('Remove "{}" sink ...'.format(bridge.sink.name))
+                self.delete_null_sink(bridge.sink.module.index)
+                self.bridges.remove(bridge)
+                self.update()
+                logger.info('Removed the device "{name}."'.format(
+                    name=device.name))
+                break

--- a/pulseaudio_dlna/renderers.py
+++ b/pulseaudio_dlna/renderers.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+
+# This file is part of pulseaudio-dlna.
+
+# pulseaudio-dlna is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# pulseaudio-dlna is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with pulseaudio-dlna.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import logging
+
+logger = logging.getLogger('pulseaudio_dlna.renderers')
+
+
+class RendererHolder(object):
+    def __init__(self, device_filter=None):
+        self.renderers = {}
+        self.registered = {}
+        self.device_filter = device_filter
+
+    def register(self, identifier, _type):
+        self.registered[identifier] = _type
+
+    def _retrieve_header_map(self, header):
+        header = re.findall(r"(?P<name>.*?): (?P<value>.*?)\r\n", header)
+        header = {k.lower(): v for k, v in dict(header).items()}
+        return header
+
+    def _retrieve_device_id(self, header):
+        if 'usn' in header:
+            match = re.search("uuid:([0-9a-f\-]+)::.*", header['usn'], re.IGNORECASE)
+            if match:
+                return match.group(1)
+        return None
+
+    def _add_renderer_with_filter_check(self, device_id, device):
+        if self.device_filter is None or device.name in self.device_filter:
+            self.renderers[device_id] = device
+        else:
+            logger.info('Skipped the device "{name}."'.format(
+                name=device.name))
+
+    def add_from_search(self, header):
+        header = self._retrieve_header_map(header)
+        device_id = self._retrieve_device_id(header)
+
+        if device_id is not None and device_id not in self.renderers:
+            if 'st' in header:
+                st_header = header['st']
+                if st_header in self.registered:
+                    device = self.registered[st_header].create_device(header)
+                    if device is not None:
+                        self._add_renderer_with_filter_check(device_id, device)
+
+    def process_notify_request(self, header):
+        header = self._retrieve_header_map(header)
+        device_id = self._retrieve_device_id(header)
+
+        if device_id is not None:
+            if 'nts' in header:
+                nts_header = header['nts']
+                if nts_header == 'ssdp:alive' and device_id not in self.renderers and 'nt' in header:
+                    nt_header = header['nt']
+                    if nt_header in self.registered:
+                        device = self.registered[nt_header].create_device(header)
+                        if device is not None:
+                            self._add_renderer_with_filter_check(device_id, device)
+                elif nts_header == 'ssdp:byebye' and device_id in self.renderers:
+                    del self.renderers[device_id]
+        # TODO inform pulseaudio about changes

--- a/pulseaudio_dlna/renderers.py
+++ b/pulseaudio_dlna/renderers.py
@@ -22,10 +22,10 @@ logger = logging.getLogger('pulseaudio_dlna.renderers')
 
 
 class RendererHolder(object):
-    def __init__(self, stream_server, message_queue,plugins, device_filter=None):
+    def __init__(self, stream_server_address, message_queue, plugins, device_filter=None):
         self.renderers = {}
         self.registered = {}
-        self.stream_server = stream_server
+        self.stream_server_address = stream_server_address
         self.device_filter = device_filter
         self.message_queue = message_queue
         for plugin in plugins:
@@ -59,7 +59,8 @@ class RendererHolder(object):
 
     def _add_renderer(self, device_id, device):
         device.activate()
-        device.set_server_location(self.stream_server.ip, self.stream_server.port)
+        ip, port = self.stream_server_address
+        device.set_server_location(ip, port)
         self.renderers[device_id] = device
         self.message_queue.put({
             'type': 'add_device',

--- a/pulseaudio_dlna/renderers.py
+++ b/pulseaudio_dlna/renderers.py
@@ -32,8 +32,9 @@ class RendererHolder(object):
             self._register(plugin.st_header, plugin)
 
     def add_renderers_by_url(self, locations):
-        # TODO implement me
-        pass
+        for plugin in self.registered.values():
+            for device in plugin.lookup(locations):
+                self._add_renderer(device.udn, device)
 
     def _register(self, identifier, _type):
         self.registered[identifier] = _type
@@ -45,7 +46,7 @@ class RendererHolder(object):
 
     def _retrieve_device_id(self, header):
         if 'usn' in header:
-            match = re.search("uuid:([0-9a-f\-]+)::.*", header['usn'], re.IGNORECASE)
+            match = re.search("(uuid:[0-9a-f\-]+)::.*", header['usn'], re.IGNORECASE)
             if match:
                 return match.group(1)
         return None

--- a/pulseaudio_dlna/streamserver.py
+++ b/pulseaudio_dlna/streamserver.py
@@ -131,14 +131,10 @@ class ProcessStream(object):
                         client=self.sockets[sock].ip,
                         method=method,
                         path=self.path))
-                bridge = self.sockets[sock].bridge
                 del self.sockets[sock]
                 sock.close()
                 self.client_count -= 1
                 if len(self.sockets) == 0:
-                    self.server.message_queue.put(
-                        {'type': 'on_bridge_disconnected',
-                         'stopped_bridge': bridge})
                     logger.info('Stream closed. '
                                 'Cleaning up remaining processes ...')
                     self.update_thread.pause()


### PR DESCRIPTION
This will add the following functionality:
* an UDP listener that listens on port 1900 for incoming SSDP request
  * add not yet registered devices for 'ssdp:alive' requests (names are checked against the configurable device-filter)
  * remove registered devices for 'ssdp:byebye' requests
* some minor bug fixes

This pull request will resolve: #36 