### PR TITLE
add python-psutil >= 1.2.1 to setup requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setuptools.setup(
         "setproctitle >= 1.0.1",
         "protobuf >= 2.5.0",
         "notify2 >= 0.3",
+        "psutil >= 1.2.1",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This was missing from setup requires, as some rpm user pointed out to me.
didn't saw myself as I already had it installed.