### PR TITLE
Added Logitech Media Server to Tested devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ _pulseaudio-dlna_ was successfully tested on the following devices / application
 - Sony STR-DN1050 (AV Receiver)
 - Pure Jongo S3
 - [Volumio](http://volumio.org) 
+- Logitech Media Server
 
 ## Supported encoders ##
 


### PR DESCRIPTION
I tested pulseaudio-dlna with the Logitech Media Server running my a Synology Nas.