### PR TITLE
Use safe, escaped Popen() commands

### DIFF
--- a/pulseaudio_dlna/encoders.py
+++ b/pulseaudio_dlna/encoders.py
@@ -33,7 +33,7 @@ class UnsupportedMimeTypeException():
 class BaseEncoder(object):
     def __init__(self):
         self._binary = None
-        self._command = ''
+        self._command = []
         self._mime_type = 'undefined'
         self._mime_types = []
         self._suffix = 'undefined'
@@ -49,7 +49,7 @@ class BaseEncoder(object):
 
     @property
     def command(self):
-        return self._command.format(binary=self.binary)
+        return [self.binary] + self._command
 
     @property
     def mime_type(self):
@@ -129,8 +129,10 @@ class WavEncoder(BaseEncoder):
     def __init__(self):
         BaseEncoder.__init__(self)
         self._binary = 'sox'
-        self._command = ('{binary} -t raw -b 16 -e signed -c 2 -r 44100 - -t wav '
-                         '-r 44100 -b 16 -L -e signed -c 2 -')
+        self._command = ['-t', 'raw', '-b', '16', '-e', 'signed', '-c', '2',
+                         '-r', '44100', '-',
+                         '-t', 'wav', '-b', '16', '-e', 'signed', '-c', '2',
+                         '-r', '44100', '-L', '-']
         self._mime_type = 'audio/wav'
         self._suffix = 'wav'
         self._mime_types = ['audio/wav', 'audio/x-wav']
@@ -152,7 +154,7 @@ class LameEncoder(BaseEncoder):
     def __init__(self):
         BaseEncoder.__init__(self)
         self._binary = 'lame'
-        self._command = '{binary} {bit_rate} -r -'
+        self._command = ['-r', '-']
         self._mime_type = 'audio/mpeg'
         self._suffix = 'mp3'
         self._mime_types = ['audio/mpeg', 'audio/mp3']
@@ -164,18 +166,18 @@ class LameEncoder(BaseEncoder):
 
     @property
     def command(self):
+        command = super(LameEncoder, self).command
         if self.bit_rate is None:
-            return self._command.format(binary=self.binary, bit_rate='')
+            return command + self._command
         else:
-            return self._command.format(
-                binary=self.binary, bit_rate='-b ' + str(self.bit_rate))
+            return command + ['-b', str(self.bit_rate)] + self._command
 
 
 class AacEncoder(BaseEncoder):
     def __init__(self):
         BaseEncoder.__init__(self)
         self._binary = 'faac'
-        self._command = '{binary} {bit_rate} -X -P -o - -'
+        self._command = ['-X', '-P', '-o', '-', '-']
         self._mime_type = 'audio/aac'
         self._suffix = 'aac'
         self._mime_types = ['audio/aac', 'audio/x-aac']
@@ -187,20 +189,20 @@ class AacEncoder(BaseEncoder):
 
     @property
     def command(self):
+        command = super(AacEncoder, self).command
         if self.bit_rate is None:
-            return self._command.format(binary=self.binary, bit_rate='')
+            return command + self._command
         else:
-            return self._command.format(
-                binary=self.binary, bit_rate='-b ' + str(self.bit_rate))
+            return command + ['-b', str(self.bit_rate)] + self._command
 
 
 class FlacEncoder(BaseEncoder):
     def __init__(self):
         BaseEncoder.__init__(self)
         self._binary = 'flac'
-        self._command = ('{binary} - -c --channels 2 --bps 16 '
-                         '--sample-rate 44100 '
-                         '--endian little --sign signed -s')
+        self._command = ['-', '-c', '--channels', '2', '--bps', '16',
+                         '--sample-rate', '44100'
+                         '--endian little', '--sign', 'signed', '-s']
         self._mime_type = 'audio/flac'
         self._suffix = 'flac'
         self._mime_types = ['audio/flac', 'audio/x-flac']
@@ -222,7 +224,7 @@ class OggEncoder(BaseEncoder):
     def __init__(self):
         BaseEncoder.__init__(self)
         self._binary = 'oggenc'
-        self._command = '{binary} {bit_rate} -Q -r --ignorelength -'
+        self._command = ['-Q', '-r', '--ignorelength', '-']
         self._mime_type = 'audio/ogg'
         self._suffix = 'ogg'
         self._mime_types = ['audio/ogg', 'audio/x-ogg', 'application/ogg']
@@ -240,20 +242,21 @@ class OggEncoder(BaseEncoder):
 
     @property
     def command(self):
+        command = super(OggEncoder, self).command
         if self.bit_rate is None:
-            return self._command.format(binary=self.binary, bit_rate='')
+            return command + self._command
         else:
-            return self._command.format(
-                binary=self.binary, bit_rate='-b ' + str(self.bit_rate))
+            return command + ['-b', str(self.bit_rate)] + self._command
 
 
 class OpusEncoder(BaseEncoder):
     def __init__(self):
         BaseEncoder.__init__(self)
         self._binary = 'opusenc'
-        self._command = ('{binary} {bit_rate} --padding 0 --max-delay 0 '
-                         '--expect-loss 1 --framesize 2.5 --raw-rate 44100 '
-                         '--raw --bitrate 64 - -')
+        self._command = ['--padding', '0', '--max-delay', '0',
+                         '--expect-loss', '1', '--framesize', '2.5',
+                         '--raw-rate', '44100',
+                         '--raw', '--bitrate', '64', '-', '-']
         self._mime_type = 'audio/opus'
         self._suffix = 'opus'
         self._mime_types = ['audio/opus', 'audio/x-opus']
@@ -264,8 +267,8 @@ class OpusEncoder(BaseEncoder):
 
     @property
     def command(self):
+        command = super(OggEncoder, self).command
         if self.bit_rate is None:
-            return self._command.format(binary=self.binary, bit_rate='')
+            return command + self._command
         else:
-            return self._command.format(
-                binary=self.binary, bit_rate='--bitrate ' + str(self.bit_rate))
+            return command + ['--bitrate', str(self.bit_rate)] + self._command

--- a/pulseaudio_dlna/recorders.py
+++ b/pulseaudio_dlna/recorders.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 
 class BaseRecorder(object):
     def __init__(self):
-        self._command = ''
+        self._command = []
 
     @property
     def command(self):
@@ -30,9 +30,9 @@ class BaseRecorder(object):
 class PulseaudioRecorder(BaseRecorder):
     def __init__(self, sink_path):
         BaseRecorder.__init__(self)
-        self._command = 'parec --format=s16le -d {sink_path}'
         self._sink_path = sink_path
+        self._command = ['parec', '--format=s16le']
 
     @property
     def command(self):
-        return self._command.format(sink_path=self._sink_path)
+        return self._command + ['-d', self._sink_path]

--- a/pulseaudio_dlna/streamserver.py
+++ b/pulseaudio_dlna/streamserver.py
@@ -399,7 +399,7 @@ class StreamRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             }
 
             if self.server.fake_http_content_length:
-                gb_in_bytes = 1 << 30
+                gb_in_bytes = pow(1024, 3)
                 headers['Content-Length'] = gb_in_bytes * 100
             else:
                 if self.request_version == PROTOCOL_VERSION_V10:

--- a/pulseaudio_dlna/streamserver.py
+++ b/pulseaudio_dlna/streamserver.py
@@ -25,6 +25,7 @@ import logging
 import time
 import socket
 import select
+import sys
 import gobject
 import functools
 import atexit
@@ -272,13 +273,13 @@ class ProcessStream(object):
         if self.reinitialize_count < 3:
             self.reinitialize_count += 1
             logger.debug('Starting processes "{recorder} | {encoder}"'.format(
-                recorder=self.recorder.command,
-                encoder=self.encoder.command))
+                recorder=' '.join(self.recorder.command),
+                encoder=' '.join(self.encoder.command)))
             self.recorder_process = subprocess.Popen(
-                self.recorder.command.split(' '),
+                self.recorder.command,
                 stdout=subprocess.PIPE)
             self.encoder_process = subprocess.Popen(
-                self.encoder.command.split(' '),
+                self.encoder.command,
                 stdin=self.recorder_process.stdout,
                 stdout=subprocess.PIPE)
             self.recorder_process.stdout.close()
@@ -398,7 +399,7 @@ class StreamRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             }
 
             if self.server.fake_http_content_length:
-                gb_in_bytes = 1073741824
+                gb_in_bytes = 1 << 30
                 headers['Content-Length'] = gb_in_bytes * 100
             else:
                 if self.request_version == PROTOCOL_VERSION_V10:


### PR DESCRIPTION
It is dangerous to use code like:

    Popen('binary --arg {foo}'.split(' '))

because if `{foo}` is user-controlled, it can lead to shell injection. Besides, if `{foo}` contains spaces, it will break.

An easy and reliable way to deal with that is to build argument *lists* from the beginning instead of using string templates.

I also replaced the magic number `1073741824` with `1 << 30` which makes a little more sense: want [1TiB](https://www.google.fr/search?q=1099511627776+bytes+in+TiB)? Replace 30 with 40!