### PR TITLE
Set SocketServer.allow_reuse_address=true

### DIFF
--- a/pulseaudio_dlna/listener.py
+++ b/pulseaudio_dlna/listener.py
@@ -58,6 +58,7 @@ class SSDPListener(SocketServer.UDPServer):
             stream_server_address, message_queue, plugins, device_filter,
             device_config)
         if not self.disable_ssdp_listener:
+            self.allow_reuse_address = True
             SocketServer.UDPServer.__init__(
                 self, ('', 1900), SSDPRequestHandler)
             multicast = struct.pack(


### PR DESCRIPTION
This lets us share the SSDP port happily with other running software.
The kernel forbids us to bind a second time to the same port, if there
is already a socket open. But as this is multicast it is common to have
multiple applications listening to the same multicast address and port.

Setting SO_REUSEADDR on the socket before attempting to bind() will work
happily and make use coexist with other UPnP software on the machine.