### PR TITLE
Decode HTML entities in chromecast friendlyname

### DIFF
--- a/pulseaudio_dlna/plugins/chromecast/renderer.py
+++ b/pulseaudio_dlna/plugins/chromecast/renderer.py
@@ -23,6 +23,7 @@ import urlparse
 import socket
 import traceback
 import BeautifulSoup
+from HTMLParser import HTMLParser
 
 import pycastv2
 import pulseaudio_dlna.plugins.renderer
@@ -149,7 +150,7 @@ class ChromecastRendererFactory(object):
                         model_name=model_name))
                 return None
             cast_device = type_(
-                soup.root.device.friendlyname.text,
+                HTMLParser().unescape(soup.root.device.friendlyname.text), # Unescape html entities in Chromecast's name
                 ip,
                 soup.root.device.udn.text,
                 soup.root.device.modelname.text,


### PR DESCRIPTION
Not sure if this is an acceptable fix to you, but after some experimentation I couldn't find a way for beautifulsoup/requests to automatically decode html entities.
Resolves #117