### PR TITLE
Add workaround for Yamaha receivers

### DIFF
--- a/pulseaudio_dlna/workarounds.py
+++ b/pulseaudio_dlna/workarounds.py
@@ -18,9 +18,9 @@
 from __future__ import unicode_literals
 
 import logging
+from lxml import etree
 import requests
 import urlparse
-import BeautifulSoup
 
 
 logger = logging.getLogger('pulseaudio_dlna.workarounds')
@@ -51,57 +51,293 @@ class BaseWorkaround(object):
 
 
 class YamahaWorkaround(BaseWorkaround):
-
+    # Misc constants
     REQUEST_TIMEOUT = 5
     ENCODING = 'utf-8'
+    URL_FORMAT = 'http://{ip}:{port}{url}'
 
-    XML_PUT = ('<YAMAHA_AV cmd="PUT"><{zone}><{category}><{key}>{value}'
-               '</{key}></{category}></{zone}></YAMAHA_AV>')
+    # MediaRenderer constants
+    MR_YAMAHA_PREFIX = 'yamaha'
+    MR_YAMAHA_DEVICE = MR_YAMAHA_PREFIX +':' +'X_device'
+    MR_YAMAHA_URLBASE = MR_YAMAHA_PREFIX +':' +'X_URLBase'
+    MR_YAMAHA_SERVICELIST = MR_YAMAHA_PREFIX +':' +'X_serviceList'
+    MR_YAMAHA_SERVICE = MR_YAMAHA_PREFIX +':' +'X_service'
+    MR_YAMAHA_CONTROLURL= MR_YAMAHA_PREFIX +':' +'X_controlURL'
+
+    MR_YAMAHA_URLBASE_PATH = '/'.join([MR_YAMAHA_DEVICE, MR_YAMAHA_URLBASE])
+    MR_YAMAHA_CONTROLURL_PATH = '/'.join(
+        [MR_YAMAHA_DEVICE, MR_YAMAHA_SERVICELIST, MR_YAMAHA_SERVICE,
+         MR_YAMAHA_CONTROLURL])
+
+    # YamahaRemoteControl constants
+    YRC_TAG_ROOT = 'YAMAHA_AV'
+    YRC_KEY_RC = 'RC'
+    YRC_CMD_GETPARAM = 'GetParam'
+    YRC_BASEPATH_CONFIG = 'Config'
+    YRC_BASEPATH_BASICSTATUS = 'Basic_Status'
+    YRC_BASEPATH_FEAURES = 'Feature_Existence'
+    YRC_BASEPATH_INPUTNAMES = 'Name/Input'
+    YRC_BASEPATH_POWER = 'Power_Control/Power'
+    YRC_BASEPATH_SOURCE = 'Input/Input_Sel'
+    YRC_VALUE_POWER_ON = 'On'
+    YRC_VALUE_POWER_OFF = 'Standby'
+
+    YRC_REQUEST_CONTENTTYPE = 'text/xml; charset="{encoding}"'.format(
+        encoding=ENCODING)
+    YRC_REQUEST_TEMPLATE = \
+        '<?xml version="1.0" encoding="{encoding}"?>' \
+        '<YAMAHA_AV cmd="{cmd}">{request}</YAMAHA_AV>'
+
+    # Known server modes
+    YRC_SERVER_MODES = [ 'SERVER', 'PC' ]
 
     def __init__(self, xml):
         BaseWorkaround.__init__(self)
+        self.enabled = False
+
         self.control_url = None
-        self._parse_xml(xml)
+        self.ip = None
+        self.port = None
 
-    def before_play(self):
-        if self.control_url:
-            self.set_source('PC')
+        self.zones = None
+        self.sources = None
+
+        self.server_mode_zone = None
+        self.server_mode_source = None
+
+        # Initialize YamahaRemoteControl interface
+        if (not self._detect_remotecontrolinterface(xml)):
+            logger.warning(
+                'Automatic source switching will not be enabled'
+                ' - Please switch to server mode manually to enable UPnP'
+                    ' streaming'
+            )
+            return
+
+        self.enabled = True
+
+
+    def _detect_remotecontrolinterface(self, xml):
+        # Check for YamahaRemoteControl support
+        if (not self._parse_xml(xml)):
+            logger.info('No Yamaha RemoteControl interface detected')
+            return False
+        logger.info('Yamaha RemoteControl found: ' +self.URL_FORMAT.format(
+            ip=self.ip, port=self.port, url=self.control_url))
+        # Get supported features
+        self.zones, self.sources = self._query_supported_features()
+        # Determine main zone
+        logger.info('Supported zones: ' +', '.join(self.zones))
+        self.server_mode_zone = self.zones[0]
+        logger.info('Using \'{zone}\' as main zone'.format(
+            zone=self.server_mode_zone
+        ))
+        # Determine UPnP server source
+        if (self.sources):
+            logger.info('Supported sources: ' +', '.join(self.sources))
+            for source in self.YRC_SERVER_MODES:
+                if (source not in self.sources):
+                    continue
+                self.server_mode_source = source
+                break
         else:
-            logger.error(
-                'Not sending Yamaha AVRC command. No control url found!')
-
-    def set_source(self, mode='PC'):
-        self._put('Main Zone', 'Input', 'Input_Sel', mode)
+            logger.warning('Querying supported features failed')
+        if (not self.server_mode_source):
+            logger.warning('Unable to determine UPnP server mode source')
+            return False
+        logger.info('Using \'{source}\' as UPnP server mode source'.format(
+            source=self.server_mode_source
+        ))
+        return True
 
     def _parse_xml(self, xml):
-        soup = BeautifulSoup.BeautifulSoup(xml)
-        for device in soup.root.findAll('yamaha:x_device'):
-            url_base = device.find('yamaha:x_urlbase')
-            control_path = device.find('yamaha:x_controlurl')
-            if url_base and control_path:
-                self.control_url = urlparse.urljoin(
-                    url_base.text, control_path.text)
+        # Parse MediaRenderer description XML
+        xml_root = etree.fromstring(xml)
+        namespaces = xml_root.nsmap
+        namespaces.pop(None, None)
 
-    def _put(self, zone, category, key, value):
+        # Determine AVRC URL
+        url_base = xml_root.find(self.MR_YAMAHA_URLBASE_PATH, namespaces)
+        control_url = xml_root.find(self.MR_YAMAHA_CONTROLURL_PATH, namespaces)
+        if ((url_base is None) or (control_url is None)):
+            return False
+        ip, port = urlparse.urlparse(url_base.text).netloc.split(':')
+        if ((not ip) or (not port)):
+            return False
+
+        self.ip = ip
+        self.port = port
+        self.control_url = control_url.text
+        return True
+
+
+    def _generate_request(self, cmd, root, path, value):
+        # Generate headers
         headers = {
-            'Content-Type':
-                'text/xml; charset="{encoding}"'.format(
-                    encoding=self.ENCODING),
+            'Content-Type': self.YRC_REQUEST_CONTENTTYPE,
         }
-        data = self.XML_PUT.format(
-            zone=zone, category=category, key=key, value=value)
+        # Generate XML request
+        tags = path.split('/')
+        if (root):
+            tags = [root] + tags
+        request = ''
+        for tag in tags:
+            request += '<{tag}>'.format(tag=tag)
+        request += value
+        for tag in reversed(tags):
+            request += '</{tag}>'.format(tag=tag)
+        body = self.YRC_REQUEST_TEMPLATE.format(
+            encoding=self.ENCODING,
+            cmd=cmd,
+            request=request,
+        )
+        # Construct URL
+        url = self.URL_FORMAT.format(
+            ip=self.ip,
+            port=self.port,
+            url=self.control_url,
+        )
+        return headers, body, url
+
+    def _get(self, root, path, value, filter_path=None):
+        # Generate request
+        headers, data, url = self._generate_request('GET', root, path, value)
+        # POST request
         try:
-            logger.debug(
-                'Yamaha AVRC command - POST request: {request}'.format(
-                    request=data))
+            logger.debug('Yamaha RC request: '+data)
             response = requests.post(
-                self.control_url, data.encode(self.ENCODING),
+                url, data.encode(self.ENCODING),
                 headers=headers, timeout=self.REQUEST_TIMEOUT)
-            logger.debug(
-                'Yamaha AVRC command - POST response: {response}'.format(
-                    response=response.text))
+            logger.debug('Yamaha RC response: ' +response.text)
+            if response.status_code != 200:
+                logger.error(
+                    'Yamaha RC request failed - Status code: {code}'.format(
+                        code=response.status_code))
+                return None
         except requests.exceptions.Timeout:
-            logger.error(
-                'Yamaha AVRC {category} command - Could no connect to {url}. '
-                'Connection timeout.'.format(
-                    url=self.control_url, category=category))
+            logger.error('Yamaha RC request failed - Connection timeout')
+            return None
+        # Parse response
+        xml_root = etree.fromstring(response.content)
+        if (xml_root.tag != self.YRC_TAG_ROOT):
+            logger.error("Malformed response: Root tag missing")
+            return None
+        # Parse response code
+        rc = xml_root.get(self.YRC_KEY_RC)
+        if (not rc):
+            logger.error("Malformed response: RC attribute missing")
+            return None
+        rc = int(rc)
+        if (rc > 0):
+            logger.error('Yamaha RC request failed - Response code: {code}'.
+                format(code=rc))
+            return rc
+        # Only return subtree
+        result_path = []
+        if (root):
+            result_path.append(root)
+        result_path.append(path)
+        if (filter_path):
+            result_path.append(filter_path)
+        result_path = '/'.join(result_path)
+        return xml_root.find(result_path)
+
+    def _put(self, root, path, value):
+        # Generate request
+        headers, data, url = self._generate_request('PUT', root, path, value)
+        # POST request
+        try:
+            logger.debug('Yamaha RC request: '+data)
+            response = requests.post(
+                url, data.encode(self.ENCODING),
+                headers=headers, timeout=self.REQUEST_TIMEOUT)
+            logger.debug('Yamaha RC response: ' +response.text)
+            if response.status_code != 200:
+                logger.error(
+                    'Yamaha RC request failed - Status code: {code}'.format(
+                        code=response.status_code))
+                return False
+        except requests.exceptions.Timeout:
+            logger.error('Yamaha RC request failed - Connection timeout')
+            return None
+        # Parse response
+        xml_root = etree.fromstring(response.content)
+        if (xml_root.tag != self.YRC_TAG_ROOT):
+            logger.error("Malformed response: Root tag missing")
+            return None
+        # Parse response code
+        rc = xml_root.get(self.YRC_KEY_RC)
+        if (not rc):
+            logger.error("Malformed response: RC attribute missing")
+            return None
+        rc = int(rc)
+        if (rc > 0):
+            logger.error('Yamaha RC request failed - Response code: {code}'.
+                format(code=rc))
+            return rc
+        return 0
+
+
+    def _query_supported_features(self):
+        xml_response = self._get('System', 'Config', self.YRC_CMD_GETPARAM)
+        if (xml_response is None):
+            return None
+
+        xml_features = xml_response.find(self.YRC_BASEPATH_FEAURES)
+        xml_names = xml_response.find(self.YRC_BASEPATH_INPUTNAMES)
+        if (xml_features is None):
+            return None
+
+        # Features can be retrieved in different ways, most probably
+        # dependending on the recever's firmware / protocol version
+        # Here are the different responses known up to now:
+        #
+        # 1. Comma-separated list of all features in one single tag, containing
+        #    all input sources
+        # 2. Each feature is enclosed by a tag along with context information
+        #    depending on the XML path:
+        #    - YRC_BASEPATH_FEAURES: availability and/or support
+        #      (0 == not supported, 1 == supported)
+        #    - YRC_BASEPATH_INPUTNAMES: input/source name
+        #    Every feature is a input source, if it does not contain the
+        #    substring 'Zone'. Otherwise, it is a zone supported by the
+        #    receiver.
+        zones = []
+        sources = []
+        if (xml_features.text):
+            # Format 1:
+            sources = xml_features.text.split(',')
+        else:
+            # Format 2:
+            for child in xml_features.getchildren():
+                if ((not child.text) or (int(child.text) == 0)):
+                    continue
+                if ('Zone' in child.tag):
+                    zones.append(child.tag)
+                else:
+                    sources.append(child.tag)
+            for child in xml_names.getchildren():
+                sources.append(child.tag)
+
+        # If we got no zones up to now, we have to assume, that the receiver
+        # has no multi zone support. Thus there can be only one!
+        # Let's call it "System" and pray for the best!
+        if (len(zones) == 0):
+            zones.append('System')
+
+        return zones, sources
+
+
+
+
+    def _set_source(self, value, zone=None):
+        if (not zone):
+            zone = self.server_mode_zone
+        self._put(zone, self.YRC_BASEPATH_SOURCE, value)
+
+
+    def before_play(self):
+        if (not self.enabled):
+            return
+        logger.info('Switching to UPnP server mode')
+        self._set_source(self.server_mode_source)

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setuptools.setup(
         "futures >= 2.1.6",
         "chardet >= 2.0.1",
         "netifaces >= 0.8",
+        "lxml >= 3",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Prior starting the audio stream, the receiver is put into UPnP
serer mode by switching to the appropriate source.