### PR TITLE
added codec tests for Yamaha RX-475

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ Samsung Smart TV LED40 (UE40ES6100)                                             
 Samsung Smart TV LED48 (UE48JU6560)                                             | :white_check_mark:                | :white_check_mark:                | :white_check_mark:                | :white_check_mark:                | :white_circle:<sup>2</sup>        | :no_entry_sign:                   | :no_entry_sign:
 Xbmc / Kodi                                                                     | :white_check_mark:                | :white_check_mark:                | :white_check_mark:                | :no_entry_sign:                   | :white_circle:<sup>2</sup>        | :white_circle:<sup>2</sup>        | :white_check_mark:
 Philips Streamium NP2500 Network Player                                         | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:
-Yamaha RX-475 (AV Receiver)                                                     | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:
+Yamaha RX-475 (AV Receiver)<sup>4</sup>                                         | :white_check_mark:                | :white_check_mark:                | :no_entry_sign:                   | :white_circle:<sup>7</sup>    | :white_check_mark:                | :no_entry_sign:                   | :white_check_mark:
 Yamaha RX-V573 (AV Receiver) <sup>6</sup>                                       | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:
 Majik DSM                                                                       | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:
 [Pi MusicBox](http://www.woutervanwijk.nl/pimusicbox/)                          | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:                   | :grey_question:
@@ -649,6 +649,8 @@ Xbox 360                                                                        
 <sup>5</sup>) Was reported to buffer really long. Approximately 45 seconds
 
 <sup>6</sup>) Was reported to have issues being discovered. Make sure you run the latest firmware
+
+<sup>7</sup>) Works, but unstable: Disconnects immediately when stream interrupts (Encoder slow, packet loss, ...)
 
 ## Supported encoders ##
 


### PR DESCRIPTION
* that device seems to dislike L16 streaming with 48k sample rate. issue could be on my side, not sure. by default, the higher prioritized setting is 44,1k anyway, which works
* only lame and L16 with 1 or 2 channels plus 44,1k or 48k get automatically detected