### PR TITLE
 Add Freebox Mini Player support

### DIFF
--- a/pulseaudio_dlna/plugins/chromecast/renderer.py
+++ b/pulseaudio_dlna/plugins/chromecast/renderer.py
@@ -31,7 +31,7 @@ import pulseaudio_dlna.codecs
 logger = logging.getLogger('pulseaudio_dlna.plugins.chromecast.renderer')
 
 
-CHROMECAST_MODEL_NAMES = ['Eureka Dongle', 'Chromecast Audio']
+CHROMECAST_MODEL_NAMES = ['Eureka Dongle', 'Chromecast Audio', 'Freebox Player Mini']
 
 
 class ChromecastRenderer(pulseaudio_dlna.plugins.renderer.BaseRenderer):


### PR DESCRIPTION
The Freebox Mini Player is an AndroidTV enabled set-top-box provided by the french ISP free (http://free.fr)

Tested on Archlinux.