### PR TITLE
Added Nexus Player device to chormecast devies

### DIFF
--- a/pulseaudio_dlna/plugins/chromecast/renderer.py
+++ b/pulseaudio_dlna/plugins/chromecast/renderer.py
@@ -31,7 +31,7 @@ import pulseaudio_dlna.codecs
 logger = logging.getLogger('pulseaudio_dlna.plugins.chromecast.renderer')
 
 
-CHROMECAST_MODEL_NAMES = ['Eureka Dongle', 'Chromecast Audio', 'Freebox Player Mini']
+CHROMECAST_MODEL_NAMES = ['Eureka Dongle', 'Chromecast Audio', 'Freebox Player Mini', 'Nexus Player']
 
 
 class ChromecastRenderer(pulseaudio_dlna.plugins.renderer.BaseRenderer):


### PR DESCRIPTION
I couldn't cast to my nexus player:

`02-16 10:37:37 pulseaudio_dlna.plugins.chromecast.renderer    INFO     The Chromecast seems not to be an original Chromecast! Model name: "Nexus Player" Skipping device ...`

after adding it to the list it casts just fine