### PR TITLE
Added flac codec option and prioritized wav codec

### DIFF
--- a/pulseaudio_dlna/plugins/chromecast/renderer.py
+++ b/pulseaudio_dlna/plugins/chromecast/renderer.py
@@ -51,10 +51,11 @@ class ChromecastRenderer(pulseaudio_dlna.plugins.renderer.BaseRenderer):
             self.set_rules_from_config(config)
         else:
             self.codecs = [
+                pulseaudio_dlna.codecs.WavCodec(),
+                pulseaudio_dlna.codecs.FlacCodec(),
                 pulseaudio_dlna.codecs.Mp3Codec(),
                 pulseaudio_dlna.codecs.AacCodec(),
                 pulseaudio_dlna.codecs.OggCodec(),
-                pulseaudio_dlna.codecs.WavCodec(),
             ]
 
     def _get_media_player(self):


### PR DESCRIPTION
The flac codec is supported by chromecast while disabled in the default configuration.
I tested it modifying the json config and when found it working I modified the source accordingly.

Also wav and flac encoding gives me better latency than mp3, with wav giving the best results.