### PR TITLE
Fix for Pioneer sc-lx76

### DIFF
--- a/pulseaudio_dlna/plugins/upnp/renderer.py
+++ b/pulseaudio_dlna/plugins/upnp/renderer.py
@@ -307,7 +307,7 @@ class UpnpMediaRenderer(pulseaudio_dlna.plugins.renderer.BaseRenderer):
                     return xml_root.find('.//{*}CurrentTransportState').text
                 except:
                     logger.error(
-                        'No2 valid XML returned from {url}.'.format(url=url))
+                        'No valid XML returned from {url}.'.format(url=url))
                     return None
         except requests.exceptions.Timeout:
             logger.error(
@@ -349,7 +349,7 @@ class UpnpMediaRenderer(pulseaudio_dlna.plugins.renderer.BaseRenderer):
                     return mime_types
                 except:
                     logger.error(
-                        'No1 valid XML returned from {url}.'.format(url=url))
+                        'No valid XML returned from {url}.'.format(url=url))
                     return None
         except requests.exceptions.Timeout:
             logger.error(

--- a/pulseaudio_dlna/plugins/upnp/renderer.py
+++ b/pulseaudio_dlna/plugins/upnp/renderer.py
@@ -307,7 +307,7 @@ class UpnpMediaRenderer(pulseaudio_dlna.plugins.renderer.BaseRenderer):
                     return xml_root.find('.//{*}CurrentTransportState').text
                 except:
                     logger.error(
-                        'No valid XML returned from {url}.'.format(url=url))
+                        'No2 valid XML returned from {url}.'.format(url=url))
                     return None
         except requests.exceptions.Timeout:
             logger.error(
@@ -349,7 +349,7 @@ class UpnpMediaRenderer(pulseaudio_dlna.plugins.renderer.BaseRenderer):
                     return mime_types
                 except:
                     logger.error(
-                        'No valid XML returned from {url}.'.format(url=url))
+                        'No1 valid XML returned from {url}.'.format(url=url))
                     return None
         except requests.exceptions.Timeout:
             logger.error(
@@ -513,6 +513,8 @@ class UpnpMediaRendererFactory(object):
         url_object = urlparse.urlparse(url)
         ip, port = url_object.netloc.split(':')
         try:
+	    # Pioneer sc-lx76 returns unvalid namespace in description.xml, converting it to valid	
+	    xml = xml.replace('xmlns:ms=" urn:microsoft-com', 'xmlns:ms="urn:microsoft-com')
             xml_root = lxml.etree.fromstring(xml)
             services = []
             for device in xml_root.findall('.//{*}device'):


### PR DESCRIPTION
Pioneer sc-lx76 (possibly others) gives unvalid description.xml. There is a space before urn. Replacing it to valid namespace fixes this and after this oneliner pulseaudio-dlna works.

<root
  xmlns="urn:schemas-upnp-org:device-1-0"
  xmlns:ms=" urn:microsoft-com:wmc-1-0"
  xmlns:pnpx="http://schemas.microsoft.com/windows/pnpx/2005/11"
  xmlns:df="http://schemas.microsoft.com/windows/2008/09/devicefoundation">
