### PR TITLE
more stability when using multiple dlna sources with the same name

### DIFF
--- a/pulseaudio_dlna/pulseaudio.py
+++ b/pulseaudio_dlna/pulseaudio.py
@@ -764,10 +764,21 @@ class PulseWatcher(PulseAudio):
                 name=device.name))
 
     def update_device(self, device):
+
+        number_of_identical_devices = 0
+
+        for bridge in self.bridges:
+            if bridge.device == device and bridge.device.ip == device.ip and bridge.device.port == device.port:
+                number_of_identical_devices = number_of_identical_devices + 1
+
         for bridge in self.bridges:
             if bridge.device == device:
                 if bridge.device.ip != device.ip or \
                    bridge.device.port != device.port:
+                    
+                    if number_of_identical_devices >= 1:
+                        continue
+                    
                     bridge.device.ip = device.ip
                     bridge.device.port = device.port
                     logger.info(


### PR DESCRIPTION
using two Sonos speakers with the exact same name, pulseaudio-dlna kept updating one configuration with the other, and vice versa. This patch checks if an identical device exists, and if it does, skips the update.
