### PR TITLE
Just set encoder bit rates if the encoder supports it but do not rais…

### DIFF
--- a/pulseaudio_dlna/encoders/__init__.py
+++ b/pulseaudio_dlna/encoders/__init__.py
@@ -60,8 +60,6 @@ def set_bit_rate(bit_rate):
            hasattr(_type, 'SUPPORTED_BIT_RATES'):
             if bit_rate in _type.SUPPORTED_BIT_RATES:
                 _type.DEFAULT_BIT_RATE = bit_rate
-            else:
-                raise UnsupportedBitrateException(bit_rate, _type)
 
 
 class BaseEncoder(object):


### PR DESCRIPTION
…e an exception if not. Otherwise you are limited to the least highest encoder value for CLI options, even when the actual encoder supports it.
