### PR TITLE
Compare devices based on their UDN not on their name

### DIFF
--- a/pulseaudio_dlna/plugins/renderer.py
+++ b/pulseaudio_dlna/plugins/renderer.py
@@ -298,15 +298,15 @@ class BaseRenderer(object):
 
     def __eq__(self, other):
         if isinstance(other, BaseRenderer):
-            return self.short_name == other.short_name
+            return self.udn == other.udn
         if isinstance(other, pulseaudio_dlna.pulseaudio.PulseBridge):
-            return self.short_name == other.device.short_name
+            return self.udn == other.device.udn
 
     def __gt__(self, other):
         if isinstance(other, BaseRenderer):
-            return self.short_name > other.short_name
+            return self.udn > other.udn
         if isinstance(other, pulseaudio_dlna.pulseaudio.PulseBridge):
-            return self.short_name > other.device.short_name
+            return self.udn > other.device.udn
 
     def __str__(self, detailed=False):
         return (


### PR DESCRIPTION
- This fixes a bug where multiple devices named equally updated each other all the time