### PR TITLE
Kill processes instantly when the stream-server shuts down

### DIFF
--- a/pulseaudio_dlna/streamserver.py
+++ b/pulseaudio_dlna/streamserver.py
@@ -48,6 +48,9 @@ PROTOCOL_VERSION_V11 = 'HTTP/1.1'
 
 
 class ProcessStream(object):
+
+    RUNNING = True
+
     def __init__(self, path, sock, recorder, encoder, bridge):
         self.path = path
         self.sock = sock
@@ -65,7 +68,7 @@ class ProcessStream(object):
             10000, self._on_regenerate_reinitialize_count)
 
     def run(self):
-        while True:
+        while self.RUNNING:
             if not self.do_processes_exist():
                 self.create_processes()
                 logger.info(
@@ -427,6 +430,7 @@ class GobjectMainLoopMixin:
     def shutdown(self, *args):
         logger.info(
             'StreamServer GobjectMainLoopMixin.shutdown()')
+        ProcessStream.RUNNING = False
         try:
             self.socket.shutdown(socket.SHUT_RDWR)
         except socket.error:


### PR DESCRIPTION
- This prevents the stream-server subprocess from freezing when there are running encoder processes