### PR TITLE
An Emtec N200 (Issue #310) provides "audio/mpegurl" as first mime typ…

### DIFF
--- a/pulseaudio_dlna/codecs.py
+++ b/pulseaudio_dlna/codecs.py
@@ -94,6 +94,7 @@ class BaseCodec(object):
     IDENTIFIER = None
     BACKEND = 'generic'
     PRIORITY = None
+    BLACKLISTED_MIME_TYPES = []
 
     def __init__(self):
         self.mime_type = None
@@ -133,8 +134,11 @@ class BaseCodec(object):
 
     @classmethod
     def accepts(cls, mime_type):
+        lower_mime_type = mime_type.lower()
+        if lower_mime_type in cls.BLACKLISTED_MIME_TYPES:
+            return False
         for accepted_mime_type in cls.SUPPORTED_MIME_TYPES:
-            if mime_type.lower().startswith(accepted_mime_type.lower()):
+            if lower_mime_type.startswith(accepted_mime_type.lower()):
                 return True
         return False
 
@@ -195,6 +199,7 @@ class BitRateMixin(object):
 class Mp3Codec(BitRateMixin, BaseCodec):
 
     SUPPORTED_MIME_TYPES = ['audio/mpeg', 'audio/mp3']
+    BLACKLISTED_MIME_TYPES = ['audio/mpegurl']
     IDENTIFIER = 'mp3'
     ENCODERS = {
         'generic': pulseaudio_dlna.encoders.LameMp3Encoder,


### PR DESCRIPTION
…e accepted by the Mp3Codec class. This leads to the situation that for later play instructions also that mime type is being used. The device certainly expects a text file containing urls and not a byte stream, resulting in an error.

- Since the streaming server does not know the concept of mpegurls, simply blacklist them.