### PR TITLE
Wait for Chromecast device to be ready

### DIFF
--- a/pulseaudio_dlna/plugins/chromecast/renderer.py
+++ b/pulseaudio_dlna/plugins/chromecast/renderer.py
@@ -65,6 +65,7 @@ class ChromecastRenderer(pulseaudio_dlna.plugins.renderer.BaseRenderer):
     def _create_pychromecast(self):
         chromecast = pychromecast._get_chromecast_from_host(
             (self.ip, self.port, self.udn, self.model_name, self.name))
+        chromecast.wait()
         return chromecast
 
     def play(self, url=None, codec=None, artist=None, title=None, thumb=None):


### PR DESCRIPTION
Without waiting for the Chromecast device (Mi Box 3) to be ready, I get network errors and no sound. This patch is in accordance with `pychromecast` docs.

Note, I'm attempting to merge this into the `python3` branch, not `master`, for hopefully obvious reasons. I'll ping in #389 as well.